### PR TITLE
Add surface annotation toolbox

### DIFF
--- a/napari_process_points_and_surfaces/__init__.py
+++ b/napari_process_points_and_surfaces/__init__.py
@@ -10,9 +10,15 @@ from napari_tools_menu import register_function, register_action
 import numpy as np
 import napari
 
+from ._surface_annotation import surface_annotator
+
 from napari_time_slicer import time_slicer
 from ._quantification import add_quality, Quality, add_curvature_scalars,\
     Curvature, add_spherefitted_curvature, surface_quality_table
+
+@napari_hook_implementation
+def napari_experimental_provide_dock_widget():
+    return surface_annotator
 
 @napari_hook_implementation
 def napari_experimental_provide_function():

--- a/napari_process_points_and_surfaces/_surface_annotation.py
+++ b/napari_process_points_and_surfaces/_surface_annotation.py
@@ -13,6 +13,9 @@ from magicgui.widgets import create_widget
 from napari.layers import Surface
 from scipy import spatial
 
+from napari_tools_menu import register_dock_widget
+
+@register_dock_widget(menu = "Surfaces > Annotate surface manually (nppas)")
 class surface_annotator(QWidget):
     """Comprehensive stress analysis of droplet points layer."""
 
@@ -59,10 +62,6 @@ class surface_annotator(QWidget):
         self.installEventFilter(self)
 
         self.currently_selected_button = None
-
-        self.tree = spatial.KDTree(self.surface_layer_select.value.data[0])
-
-        #self.surface_layer_select.value.mouse_drag_callbacks.append(self.paint_single_face)
 
     def on_push_button(self, button):
 
@@ -175,6 +174,7 @@ class surface_annotator(QWidget):
         candidate_points = layer.data[0][candidate_vertices]
         _,intersection_coords = napari.utils.geometry.find_nearest_triangle_intersection(event.position, event.view_direction, candidate_points[None, :, :])
 
+        self.tree = spatial.KDTree(self.surface_layer_select.value.data[0])
         indices = self.tree.query_ball_point(intersection_coords, r=10)
 
         original_values = layer.data[2]
@@ -224,7 +224,6 @@ class surface_annotator(QWidget):
 
             #indices = tree.query_ball_point(intersection_coords, r=radius)
             indices = np.argwhere(distances <= radius)
-            print(indices)
 
             #_, triangle_index = layer.get_value(event.position, view_direction=event.view_direction, dims_displayed=event.dims_displayed, world=True)
             #layer.data[2] = original_values
@@ -235,8 +234,6 @@ class surface_annotator(QWidget):
             data = list(layer.data)
             data[2] = new_values
             self.viewer.layers[layer.name].data = data
-
-            print("done")
 
             yield
             # the yield statement allows the mouse UI to keep working while

--- a/napari_process_points_and_surfaces/_surface_annotation.py
+++ b/napari_process_points_and_surfaces/_surface_annotation.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+
+import napari
+import copy
+import numpy as np
+from pygeodesic import geodesic
+
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QPushButton, QButtonGroup, QSpinBox
+from qtpy.QtCore import QEvent, QObject
+
+from magicgui.widgets import create_widget
+
+from napari.layers import Surface
+from scipy import spatial
+
+class surface_annotator(QWidget):
+    """Comprehensive stress analysis of droplet points layer."""
+
+    def __init__(self, napari_viewer):
+        super().__init__()
+
+        self.selected_vertices = []
+        if "start_end_points" not in napari_viewer.layers :
+            self.points_layer = napari_viewer.add_points(np.empty((0,3)), ndim=3, name="start_end_points")
+        else:
+            self.points_layer = napari_viewer.layers["start_end_points"]
+
+        self.viewer = napari_viewer
+
+        # add input dropdowns to plugin
+        self.surface_layer_select = create_widget(annotation=Surface, label="Surface_layer")
+
+        self.tool_select_group = QButtonGroup()
+        self.tool_select_group.setExclusive(True)
+
+        self.button_single_face = QPushButton("Paint Single Face")
+        self.button_single_face.setCheckable(True)
+        self.tool_select_group.addButton(self.button_single_face)
+
+        self.button_radius = QPushButton("Radius")
+        self.button_radius.setCheckable(True)
+        self.tool_select_group.addButton(self.button_radius)
+
+        self.button_geodesic_radius = QPushButton("geodesic Radius")
+        self.button_geodesic_radius.setCheckable(True)
+        self.tool_select_group.addButton(self.button_geodesic_radius)
+
+        self.label_select_spinbox = QSpinBox()
+
+        self.setLayout(QVBoxLayout())
+
+        self.layout().addWidget(self.surface_layer_select.native, 0)
+        self.layout().addWidget(self.button_single_face)
+        self.layout().addWidget(self.button_radius)
+        self.layout().addWidget(self.button_geodesic_radius)
+        self.layout().addWidget(self.label_select_spinbox)
+
+        self.tool_select_group.buttonClicked.connect(self.on_push_button)
+        self.installEventFilter(self)
+
+        self.currently_selected_button = None
+
+        self.tree = spatial.KDTree(self.surface_layer_select.value.data[0])
+
+        #self.surface_layer_select.value.mouse_drag_callbacks.append(self.paint_single_face)
+
+    def on_push_button(self, button):
+
+        # remove previous callbacks
+        if len(self.surface_layer_select.value.mouse_drag_callbacks) > 0:
+            self.surface_layer_select.value.mouse_drag_callbacks.pop(0)
+
+        # if a button is just de-activated
+        if button == self.currently_selected_button:
+            button.setChecked(False)
+            self.surface_layer_select.value.mouse_drag_callbacks = []
+
+        if button == self.button_single_face:
+            self.surface_layer_select.value.mouse_drag_callbacks.append(self._paint_single_face)
+            self.currently_selected_button = button
+
+        if button == self.button_radius:
+            self.surface_layer_select.value.mouse_drag_callbacks.append(self._paint_face_by_eucledean_distance)
+            self.currently_selected_button = button
+
+        if button == self.button_geodesic_radius:
+            self.surface_layer_select.value.mouse_drag_callbacks.append(self._paint_face_by_geodesic_distance)
+            self.currently_selected_button = button
+
+
+    def eventFilter(self, obj: QObject, event: QEvent):
+        """https://forum.image.sc/t/composing-workflows-in-napari/61222/3."""
+        if event.type() == QEvent.ParentChange:
+            self.surface_layer_select.parent_changed.emit(self.parent())
+
+        return super().eventFilter(obj, event)
+
+    def get_napari_visual(self, viewer, layer):
+        """Get the visual class for a given layer
+        Parameters
+        ----------
+        viewer
+            The napari viewer object
+        layer
+            The napari layer object for which to find the visual.
+        Returns
+        -------
+        visual
+            The napari visual class for the layer.
+        """
+        visual = viewer.window._qt_window._qt_viewer.layer_to_visual[layer]
+
+        return visual
+
+
+    def paint_face(self, surface_layer, index):
+        data = list(surface_layer.data)
+        indeces_of_triangle_points = data[1][index]
+
+        values = data[2]
+        values[indeces_of_triangle_points] = self.label_select_spinbox.value()
+
+        surface_visual = self.get_napari_visual(self.viewer, surface_layer)
+        meshdata = surface_visual.node._meshdata
+
+        meshdata.set_vertex_values(values)
+
+        surface_visual.node.set_data(meshdata=meshdata)
+
+    def _paint_single_face(self, layer, event):
+        if "Alt" not in event.modifiers:
+            return
+
+        if self.button_single_face.isChecked():
+            _, triangle_index = layer.get_value(event.position, view_direction=event.view_direction, dims_displayed=event.dims_displayed, world=True)
+
+            candidate_vertices = layer.data[1][triangle_index]
+            candidate_points = layer.data[0][candidate_vertices]
+
+            _,intersection_coords = napari.utils.geometry.find_nearest_triangle_intersection(event.position, event.view_direction, candidate_points[None, :, :])
+
+            distances=np.linalg.norm(intersection_coords[None, :] - candidate_points, axis=1)
+            index = np.argmin(distances)
+
+            if len(self.selected_vertices) >=2:
+                self.selected_vertices.pop(0)
+            self.selected_vertices.append(candidate_vertices[index])
+
+            points = list(self.points_layer.data)
+            if len(points) >=2:
+                points.pop(0)
+                self.points_layer.data = np.asarray(points)
+
+            vertex = candidate_vertices[index]
+            self.points_layer.add(layer.data[0][vertex])
+
+            if len(self.selected_vertices) == 2:
+                geoalg = geodesic.PyGeodesicAlgorithmExact(layer.data[0], layer.data[1])
+                distance, path = geoalg.geodesicDistance(self.selected_vertices[0], self.selected_vertices[1])
+
+
+                self.viewer.add_shapes(path, shape_type = "Path")
+                self.viewer.layers.selection.active = self.surface_layer_select.value
+
+
+
+    def _paint_face_by_eucledean_distance(self, layer, event):
+        if "Alt" not in event.modifiers:
+            return
+
+        click_origin = event.position
+        _, triangle_index = layer.get_value(event.position, view_direction=event.view_direction, dims_displayed=event.dims_displayed, world=True)
+
+        candidate_vertices = layer.data[1][triangle_index]
+        candidate_points = layer.data[0][candidate_vertices]
+        _,intersection_coords = napari.utils.geometry.find_nearest_triangle_intersection(event.position, event.view_direction, candidate_points[None, :, :])
+
+        indices = self.tree.query_ball_point(intersection_coords, r=10)
+
+        original_values = layer.data[2]
+
+        yield
+        layer.interactive = False
+        while event.type == 'mouse_move':
+
+            radius = np.linalg.norm(np.asarray(click_origin) - np.asarray(event.position))
+
+            indices = self.tree.query_ball_point(intersection_coords, r=radius)
+            new_values = copy.copy(original_values)
+            new_values[indices] = self.label_select_spinbox.value()
+
+            # get data, replace values and write back
+            data = list(layer.data)
+            data[2] = new_values
+            layer.data = data
+
+            yield
+        layer.interactive = True
+
+    def _paint_face_by_geodesic_distance(self, layer, event):
+        if "Alt" not in event.modifiers:
+            return
+
+        click_origin = event.position
+        _, triangle_index = layer.get_value(event.position, view_direction=event.view_direction, dims_displayed=event.dims_displayed, world=True)
+
+        candidate_vertices = layer.data[1][triangle_index]
+        candidate_points = layer.data[0][candidate_vertices]
+        _,intersection_coords = napari.utils.geometry.find_nearest_triangle_intersection(event.position, event.view_direction, candidate_points[None, :, :])
+
+        distances=np.linalg.norm(intersection_coords[None, :] - candidate_points, axis=1)
+        index = np.argmin(distances)
+
+        geoalg = geodesic.PyGeodesicAlgorithmExact(layer.data[0], layer.data[1])
+        distances, _ = geoalg.geodesicDistances([candidate_vertices[index]], None)
+
+        original_values = layer.data[2]
+
+        yield
+        layer.interactive = False
+        while event.type == 'mouse_move':
+
+            radius = np.linalg.norm(np.asarray(click_origin) - np.asarray(event.position))
+
+            #indices = tree.query_ball_point(intersection_coords, r=radius)
+            indices = np.argwhere(distances <= radius)
+            print(indices)
+
+            #_, triangle_index = layer.get_value(event.position, view_direction=event.view_direction, dims_displayed=event.dims_displayed, world=True)
+            #layer.data[2] = original_values
+            new_values = copy.copy(original_values)
+            new_values[indices] = self.label_select_spinbox.value()
+
+            # get data, replace values and write back
+            data = list(layer.data)
+            data[2] = new_values
+            self.viewer.layers[layer.name].data = data
+
+            print("done")
+
+            yield
+            # the yield statement allows the mouse UI to keep working while
+            # this loop is executed repeatedly
+            # yield
+        layer.interactive = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,8 +46,9 @@ install_requires =
     pandas
     imageio!=2.22.1
 
+    pygeodesic
 include_package_data = True
 
-[options.entry_points] 
-napari.plugin = 
+[options.entry_points]
+napari.plugin =
     napari-process-points-and-surfaces = napari_process_points_and_surfaces


### PR DESCRIPTION
This PR adds a widget for manual annotation of surfaces with three modes:

- Facewise annotation
- annotate surfaces including all points within a mouse-drag controlled euclidian radius of a root vertex
- annotate surfaces including all points within a mouse-drag controlled geodesic radius of a root vertex