### PR TITLE
add tests for dyfunctional methods

### DIFF
--- a/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
+++ b/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
@@ -103,7 +103,7 @@ def test_smooth_surface():
 def test_subdivide_loop_vedo():
     import napari_process_points_and_surfaces as nppas
     gastruloid = nppas.gastruloid()
-    subdivided_gastruloid = nppas.subdivide_loop_vedo(gastruloid)
+    subdivided_gastruloid = nppas._subdivide_loop_vedo(gastruloid)
 
     assert len(gastruloid[0]) < len(subdivided_gastruloid[0])
 
@@ -111,7 +111,7 @@ def test_subdivide_loop_vedo():
 def test_subdivide_butterfly():
     import napari_process_points_and_surfaces as nppas
     gastruloid = nppas.gastruloid()
-    subdivided_gastruloid = nppas.subdivide_butterfly(gastruloid)
+    subdivided_gastruloid = nppas._subdivide_butterfly(gastruloid)
 
     assert len(gastruloid[0]) < len(subdivided_gastruloid[0])
 
@@ -119,7 +119,7 @@ def test_subdivide_butterfly():
 def test_subdivide_linear():
     import napari_process_points_and_surfaces as nppas
     gastruloid = nppas.gastruloid()
-    subdivided_gastruloid = nppas.subdivide_linear(gastruloid)
+    subdivided_gastruloid = nppas._subdivide_linear(gastruloid)
 
     assert len(gastruloid[0]) < len(subdivided_gastruloid[0])
 

--- a/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
+++ b/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
@@ -100,6 +100,30 @@ def test_smooth_surface():
     assert len(gastruloid[1]) == len(smoothed_gastruloid[1])
 
 
+def test_subdivide_loop_vedo():
+    import napari_process_points_and_surfaces as nppas
+    gastruloid = nppas.gastruloid()
+    subdivided_gastruloid = nppas.subdivide_loop_vedo(gastruloid)
+
+    assert len(gastruloid[0]) < len(subdivided_gastruloid[0])
+
+
+def test_subdivide_butterfly():
+    import napari_process_points_and_surfaces as nppas
+    gastruloid = nppas.gastruloid()
+    subdivided_gastruloid = nppas.subdivide_butterfly(gastruloid)
+
+    assert len(gastruloid[0]) < len(subdivided_gastruloid[0])
+
+
+def test_subdivide_linear():
+    import napari_process_points_and_surfaces as nppas
+    gastruloid = nppas.gastruloid()
+    subdivided_gastruloid = nppas.subdivide_linear(gastruloid)
+
+    assert len(gastruloid[0]) < len(subdivided_gastruloid[0])
+
+
 def test_subdivide():
     import napari_process_points_and_surfaces as nppas
     gastruloid = nppas.gastruloid()


### PR DESCRIPTION
Fixing the tests in this branch closes #57 . Before merging, remove the `_` at the beginning of the three `_subdivide` functions.

Just run
```
pytest
```

Output (excerpt):
```
=============================================== short test summary info ===============================================
FAILED napari_process_points_and_surfaces/_tests/test_vedo_functions.py::test_subdivide_loop_vedo - assert 3324 < 0
FAILED napari_process_points_and_surfaces/_tests/test_vedo_functions.py::test_subdivide_butterfly - assert 3324 < 0
FAILED napari_process_points_and_surfaces/_tests/test_vedo_functions.py::test_subdivide_linear - assert 3324 < 0
===================================== 3 failed, 16 passed, 216 warnings in 20.56s =====================================
```