### PR TITLE
Add moving least squares functions for pointclouds and surfaces

### DIFF
--- a/napari_process_points_and_surfaces/__init__.py
+++ b/napari_process_points_and_surfaces/__init__.py
@@ -38,7 +38,9 @@ from ._vedo import (to_vedo_mesh,
                     show,
                     SurfaceTuple,
                     smooth_surface_moving_least_squares_2D,
-                    smooth_surface_moving_least_squares_2D_radius
+                    smooth_surface_moving_least_squares_2D_radius,
+                    smooth_pointcloud_moving_least_squares_2D_radius,
+                    smooth_pointcloud_moving_least_squares_2D
                     )
 
 from ._utils import isotropic_scale_surface

--- a/napari_process_points_and_surfaces/__init__.py
+++ b/napari_process_points_and_surfaces/__init__.py
@@ -37,6 +37,8 @@ from ._vedo import (to_vedo_mesh,
                     decimate_pro,
                     show,
                     SurfaceTuple,
+                    smooth_surface_moving_least_squares_2D,
+                    smooth_surface_moving_least_squares_2D_radius
                     )
 
 from ._utils import isotropic_scale_surface

--- a/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
+++ b/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
@@ -99,6 +99,18 @@ def test_smooth_surface():
     assert len(gastruloid[0]) == len(smoothed_gastruloid[0])
     assert len(gastruloid[1]) == len(smoothed_gastruloid[1])
 
+    smoothed_gastruloid2 = nppas.smooth_surface_moving_least_squares_2D(gastruloid, smoothing_factor=0.2)
+    # check if vertices/faces are still the same count
+    assert len(gastruloid[0]) == len(smoothed_gastruloid2[0])
+    assert len(gastruloid[1]) == len(smoothed_gastruloid2[1])
+
+    smoothed_gastruloid3 = nppas.smooth_surface_moving_least_squares_2D_radius(gastruloid,
+                                                                               smoothing_factor=0.2,
+                                                                               radius=3)
+    # check if vertices/faces are still the same count
+    assert len(gastruloid[0]) == len(smoothed_gastruloid3[0])
+    assert len(gastruloid[1]) == len(smoothed_gastruloid3[1])
+
 
 def test_subdivide():
     import napari_process_points_and_surfaces as nppas
@@ -137,6 +149,23 @@ def test_subsample_points():
     subsampled_points = nppas.subsample_points(points, distance_fraction=0.1)
 
     assert len(points) > len(subsampled_points)
+
+
+def test_smooth_pointclouds():
+    import napari_process_points_and_surfaces as nppas
+    gastruloid = nppas.gastruloid()
+
+    points = nppas.sample_points_from_surface(gastruloid)
+
+    smoothed_points = nppas.smooth_pointcloud_moving_least_squares_2D(points,
+                                                                      smoothing_factor=0.2)
+    assert len(points) == len(smoothed_points)
+
+    smoothed_points = nppas.smooth_pointcloud_moving_least_squares_2D_radius(points,
+                                                                             smoothing_factor=0.2,
+                                                                             radius=3)
+    assert len(points) == len(smoothed_points)
+
 
 def test_create_convex_hull_from_points():
     import napari_process_points_and_surfaces as nppas

--- a/napari_process_points_and_surfaces/_vedo.py
+++ b/napari_process_points_and_surfaces/_vedo.py
@@ -173,6 +173,42 @@ def remove_duplicate_vertices(surface: "napari.types.SurfaceData") -> "napari.ty
     return to_napari_surface_data(clean_mesh)
 
 
+@register_function(menu="Surfaces > Smooth moving least squares (vedo, nppas)")
+def smooth_surface_moving_least_squares_2D(surface: "napari.types.SurfaceData",
+                                           smoothing_factor: float = 0.2) -> "napari.types.SurfaceData":
+    """Apply a moving least squares approach to smooth a surface
+
+    See Also
+    --------
+    ..[0] https://vedo.embl.es/autodocs/content/vedo/vedo/pointcloud.html#Points.smooth_mls_2d
+    """
+
+    mesh = to_vedo_mesh(surface)
+
+    smooth_mesh = mesh.smooth_mls_2d(f=smoothing_factor)
+
+    return to_napari_surface_data(smooth_mesh)
+
+
+@register_function(menu="Surfaces > Smooth moving least squares with radius (vedo, nppas)")
+def smooth_surface_moving_least_squares_2D_radius(surface: "napari.types.SurfaceData",
+                                                  smoothing_factor: float = 0.2,
+                                                  radius: float = 0.2) -> "napari.types.SurfaceData":
+    """Apply a moving least squares approach to smooth a surface. 
+    
+    The radius is used to determine the number of points to use for the smoothing.
+
+    See Also
+    --------
+    ..[0] https://vedo.embl.es/autodocs/content/vedo/vedo/pointcloud.html#Points.smooth_mls_2d
+    """
+
+    mesh = to_vedo_mesh(surface)
+
+    smooth_mesh = mesh.smooth_mls_2d(f=smoothing_factor, radius=radius)
+
+    return to_napari_surface_data(smooth_mesh)
+
 @register_function(menu="Surfaces > Smooth (vedo, nppas)")
 def smooth_surface(surface: "napari.types.SurfaceData",
                    number_of_iterations: int = 15,

--- a/napari_process_points_and_surfaces/_vedo.py
+++ b/napari_process_points_and_surfaces/_vedo.py
@@ -157,6 +157,7 @@ def create_convex_hull_from_surface(surface: "napari.types.SurfaceData") -> "nap
 
     return to_napari_surface_data(convex_hull_mesh)
 
+
 @register_function(menu="Surfaces > Remove duplicate vertices (vedo, nppas)")
 def remove_duplicate_vertices(surface: "napari.types.SurfaceData") -> "napari.types.SurfaceData":
     """
@@ -208,6 +209,44 @@ def smooth_surface_moving_least_squares_2D_radius(surface: "napari.types.Surface
     smooth_mesh = mesh.smooth_mls_2d(f=smoothing_factor, radius=radius)
 
     return to_napari_surface_data(smooth_mesh)
+
+
+@register_function(menu="Points > Smooth moving least squares (vedo, nppas)")
+def smooth_pointcloud_moving_least_squares_2D(pointcloud: "napari.types.PointsData",
+                                              smoothing_factor: float = 0.2) -> "napari.types.PointsData":
+    """Apply a moving least squares approach to smooth a point cloud.
+
+    See Also
+    --------
+    ..[0] https://vedo.embl.es/autodocs/content/vedo/vedo/pointcloud.html#Points.smooth_mls_2d
+    """
+
+    points = to_vedo_points(pointcloud)
+
+    smooth_points = points.smooth_mls_2d(f=smoothing_factor)
+
+    return to_napari_points_data(smooth_points)
+
+
+@register_function(menu="Points > Smooth moving least squares radius (vedo, nppas)")
+def smooth_pointcloud_moving_least_squares_2D_radius(pointcloud: "napari.types.PointsData",
+                                                     smoothing_factor: float = 0.2,
+                                                     radius=2) -> "napari.types.PointsData":
+    """Apply a moving least squares approach to smooth a point cloud.
+
+    The radius is used to determine the number of points to use for the smoothing.
+
+    See Also
+    --------
+    ..[0] https://vedo.embl.es/autodocs/content/vedo/vedo/pointcloud.html#Points.smooth_mls_2d
+    """
+
+    points = to_vedo_points(pointcloud)
+
+    smooth_points = points.smooth_mls_2d(f=smoothing_factor, radius=radius)
+
+    return to_napari_points_data(smooth_points)
+
 
 @register_function(menu="Surfaces > Smooth (vedo, nppas)")
 def smooth_surface(surface: "napari.types.SurfaceData",


### PR DESCRIPTION
This PR partially addresses #64.

It adds the functions `smooth_surface_moving_least_squares_2D`, `smooth_surface_moving_least_squares_2D_radius`, `smooth_pointcloud_moving_least_squares_2D` and `smooth_pointcloud_moving_least_squares_2D_radius`.

## Steps to verify quality:

- [x] Automated tests are passing
- [x] Tested all functions manually in the viewer
- [x] Added functions to demo notebook