### PR TITLE
Add error message for reconstruct surface

### DIFF
--- a/napari_process_points_and_surfaces/_vedo.py
+++ b/napari_process_points_and_surfaces/_vedo.py
@@ -543,7 +543,14 @@ def reconstruct_surface_from_pointcloud(point_cloud: "napari.types.PointsData",
         radius=point_influence_radius,
         padding=padding,
         hole_filling=fill_holes)
-    return to_napari_surface_data(mesh_out)
+
+    mesh_out = to_napari_surface_data(mesh_out)
+    if len(mesh_out[1]) == 0:
+        raise ValueError("No surface could be reconstructed with the given" +
+                         " parameters. Try to increase the number of " +
+                         "sampling voxels or the point influence radius.")
+
+    return mesh_out
 
 
 @register_function(menu="Surfaces > Convex hull of points (vedo, nppas)")


### PR DESCRIPTION
Fixes #70 

This PR adds an if clause in `reconstruct_surface_from_pointcloud` that indicates whether the used set of parameters was suitable to generate a surface mesh.

- [x] `demo.ipynb` notebook still works
- [x] error message is correctly displayed in terminal in interactive usage 