### PR TITLE
Add connected components

### DIFF
--- a/napari_process_points_and_surfaces/__init__.py
+++ b/napari_process_points_and_surfaces/__init__.py
@@ -41,7 +41,8 @@ from ._vedo import (to_vedo_mesh,
                     smooth_surface_moving_least_squares_2d_radius,
                     smooth_pointcloud_moving_least_squares_2d_radius,
                     smooth_pointcloud_moving_least_squares_2d,
-                    reconstruct_surface_from_pointcloud
+                    reconstruct_surface_from_pointcloud,
+                    connected_components_labelling
                     )
 
 from ._utils import isotropic_scale_surface

--- a/napari_process_points_and_surfaces/__init__.py
+++ b/napari_process_points_and_surfaces/__init__.py
@@ -42,7 +42,7 @@ from ._vedo import (to_vedo_mesh,
                     smooth_pointcloud_moving_least_squares_2d_radius,
                     smooth_pointcloud_moving_least_squares_2d,
                     reconstruct_surface_from_pointcloud,
-                    connected_components_labelling
+                    connected_components_labeling
                     )
 
 from ._utils import isotropic_scale_surface

--- a/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
+++ b/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
@@ -32,7 +32,7 @@ def test_connected_components():
     image[20:29, 20:29, 20:29] = 2
 
     surface = nppas.all_labels_to_surface(image)
-    connected_components = nppas.connected_components_labelling(surface)
+    connected_components = nppas.connected_components_labeling(surface)
 
     assert len(np.unique(connected_components[2])) == 3
 

--- a/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
+++ b/napari_process_points_and_surfaces/_tests/test_vedo_functions.py
@@ -23,6 +23,19 @@ def test_create_surface():
         assert num_vertices == 384
         assert num_faces == 764
 
+def test_connected_components():
+    import numpy as np
+    import napari_process_points_and_surfaces as nppas
+
+    image = np.zeros((30, 30, 30))
+    image[1:9, 1:9, 1:9] = 1
+    image[20:29, 20:29, 20:29] = 2
+
+    surface = nppas.all_labels_to_surface(image)
+    connected_components = nppas.connected_components_labelling(surface)
+
+    assert len(np.unique(connected_components[2])) == 3
+
 def test_decimate():
     import napari_process_points_and_surfaces as nppas
     from functools import partial

--- a/napari_process_points_and_surfaces/_vedo.py
+++ b/napari_process_points_and_surfaces/_vedo.py
@@ -174,8 +174,8 @@ def remove_duplicate_vertices(surface: "napari.types.SurfaceData") -> "napari.ty
     return to_napari_surface_data(clean_mesh)
 
 
-@register_function(menu="Surfaces > Connected components labelling (vedo, nppas)")
-def connected_components_labelling(surface: "napari.types.SurfaceData") -> "napari.types.SurfaceData":
+@register_function(menu="Surfaces > Connected components labeling (vedo, nppas)")
+def connected_components_labeling(surface: "napari.types.SurfaceData") -> "napari.types.SurfaceData":
     """
     Determine the connected components of a surface mesh.
 

--- a/napari_process_points_and_surfaces/_vedo.py
+++ b/napari_process_points_and_surfaces/_vedo.py
@@ -174,6 +174,25 @@ def remove_duplicate_vertices(surface: "napari.types.SurfaceData") -> "napari.ty
     return to_napari_surface_data(clean_mesh)
 
 
+@register_function(menu="Surfaces > Connected components labelling (vedo, nppas)")
+def connected_components_labelling(surface: "napari.types.SurfaceData") -> "napari.types.SurfaceData":
+    """
+    Determine the connected components of a surface mesh.
+
+    See Also
+    --------
+    ..[0] https://vedo.embl.es/docs/vedo/mesh.html#Mesh.compute_connectivity
+    """
+    mesh = to_vedo_mesh(surface)
+    mesh.compute_connectivity()
+    region_id = mesh.pointdata["RegionId"]
+
+    mesh_out = list(to_napari_surface_data(mesh))
+    mesh_out += [region_id]
+
+    return mesh_out
+
+
 @register_function(menu="Surfaces > Smooth (moving least squares, vedo, nppas)")
 def smooth_surface_moving_least_squares_2d(surface: "napari.types.SurfaceData",
                                            smoothing_factor: float = 0.2) -> "napari.types.SurfaceData":


### PR DESCRIPTION
Related to #64

This adds a function for connected components labelling on surface meshes

## QA

- [x] tested interactive usage
- [x] added tests which pass locally
- [x] added section to demo notebook  